### PR TITLE
Accept version string as CLI flag

### DIFF
--- a/cmd/olm-bundle/main.go
+++ b/cmd/olm-bundle/main.go
@@ -16,9 +16,10 @@ import (
 )
 
 type olmBundleCLI struct {
-	ChartFilePath     string `help:"Path to Helm Chart.yaml file to produce metadata." type:"path"`
+	ChartFilePath     string `help:"Path to Helm Chart.yaml file to produce metadata." type:"path" required:""`
 	OutputDir         string `help:"Output directory to save the OLM bundle files." type:"path" required:""`
 	ExtraResourcesDir string `help:"Extra resources you would like to add to the OLM bundle." type:"path"`
+	Version           string `help:"Version of the generated bundle. If not provided, value from Chart.yaml will be used"`
 }
 
 func main() {
@@ -41,17 +42,19 @@ func main() {
 	p := manifests.NewParser(extraFiles, os.Stdin)
 	resources, err := p.Parse()
 	ctx.FatalIfErrorf(err, "cannot parse resources")
+
 	result, err := csv.NewClusterServiceVersion(cli.OutputDir)
 	ctx.FatalIfErrorf(err, "cannot initialize a new ClusterServiceVersion")
-	if cli.ChartFilePath != "" {
-		hm := &manifests.HelmMetadata{
-			ChartFilePath: cli.ChartFilePath,
-		}
-		ctx.FatalIfErrorf(hm.Embed(context.TODO(), result), "cannot embed metadata from Helm Chart.yaml file")
+	hm := &manifests.HelmMetadata{
+		ChartFilePath: cli.ChartFilePath,
+		Version:       cli.Version,
 	}
+	ctx.FatalIfErrorf(hm.Embed(context.TODO(), result), "cannot embed metadata from Helm Chart.yaml file")
+
 	e := csv.NewEmbedder()
-	left, err := e.Embed(resources, result)
+	remaining, err := e.Embed(resources, result)
 	ctx.FatalIfErrorf(err, "cannot embed resources into ClusterServiceVersion file")
+
 	ann, err := csv.NewAnnotations(cli.OutputDir)
 	ctx.FatalIfErrorf(err, "cannot create a new annotations object")
 	if result.GetAnnotations() == nil {
@@ -60,9 +63,10 @@ func main() {
 	for k, v := range ann {
 		result.GetAnnotations()[k] = v
 	}
-	ctx.FatalIfErrorf(csv.Validate(left), "cannot validate")
-	out := make([]client.Object, len(left)+1)
-	for i, u := range left {
+
+	ctx.FatalIfErrorf(csv.Validate(remaining), "cannot validate")
+	out := make([]client.Object, len(remaining)+1)
+	for i, u := range remaining {
 		out[i] = u
 	}
 	out[len(out)-1] = result
@@ -75,5 +79,6 @@ func main() {
 	}
 	dir, err := b.Write()
 	ctx.FatalIfErrorf(err, "cannot write bundle")
+
 	fmt.Printf("✨ You can find your OLM bundle in %s\n🚀 Have fun!\n", dir)
 }

--- a/internal/manifests/helm.go
+++ b/internal/manifests/helm.go
@@ -18,6 +18,7 @@ import (
 // HelmMetadata writes metadata parsed from a Helm chart to ClusterServiceVersion.
 type HelmMetadata struct {
 	ChartFilePath string
+	Version       string
 }
 
 // Embed reads Chart.yaml and puts all the matching available metadata into
@@ -31,8 +32,12 @@ func (hm *HelmMetadata) Embed(ctx context.Context, csv *v1alpha1.ClusterServiceV
 	if err := yaml.Unmarshal(f, c); err != nil {
 		return errors.Wrap(err, "cannot unmarshal chart file into metadata object")
 	}
-	csv.Name = fmt.Sprintf("%s.%s", c.Name, c.Version)
-	v, err := semver.Make(c.Version)
+	ver := c.Version
+	if hm.Version != "" {
+		ver = hm.Version
+	}
+	csv.Name = fmt.Sprintf("%s.%s", c.Name, ver)
+	v, err := semver.Make(ver)
 	if err != nil {
 		return errors.Wrap(err, "cannot make a semver version from version string in Helm metadata")
 	}


### PR DESCRIPTION
Accept version string as CLI flag because the version in Chart.yaml is not the source of truth as it can be overridden during `helm package` [command](https://github.com/upbound/build/blob/f22f826/makelib/helm.mk#L81).

Manually tested.

Signed-off-by: Muvaffak Onus <me@muvaf.com>