### PR TITLE
put the string between quotes in dockerfile labels before writing it

### DIFF
--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -62,7 +62,7 @@ func (b *Bundle) writeDockerfile(path string) error {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		out += fmt.Sprintf("LABEL %s=%s\n", k, b.Metadata.Annotations[k])
+		out += fmt.Sprintf("LABEL %s=\"%s\"\n", k, b.Metadata.Annotations[k])
 	}
 	out += "\nCOPY manifests /manifests/\n"
 	out += "COPY metadata /metadata/\n"


### PR DESCRIPTION
Signed-off-by: Muvaffak Onus <me@muvaf.com>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

put the string between quotes in dockerfile labels before writing it, otherwise it doesn't support strings with spaces.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
