### PR TITLE
Some HelmCharts are versioned with vx.y.z

### DIFF
--- a/internal/manifests/helm.go
+++ b/internal/manifests/helm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/ghodss/yaml"
@@ -37,7 +38,7 @@ func (hm *HelmMetadata) Embed(ctx context.Context, csv *v1alpha1.ClusterServiceV
 		ver = hm.Version
 	}
 	csv.Name = fmt.Sprintf("%s.%s", c.Name, ver)
-	v, err := semver.Make(ver)
+	v, err := semver.Make(strings.TrimPrefix(ver, "v"))
 	if err != nil {
 		return errors.Wrap(err, "cannot make a semver version from version string in Helm metadata")
 	}


### PR DESCRIPTION
Helm is not stirct on version strictly to be SemVer. Often Helm Chart
version is synced with Docker Tag and have version prefixed with `v`.

TrimPrefix before tryint ot get SemVer out of the chart version

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
