### PR TITLE
Drop Namespace from manifests

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -47,6 +47,17 @@ func (p *Parser) Parse() ([]*unstructured.Unstructured, error) {
 	return result, nil
 }
 
+// removeNamespace removes the namespace field of resources intended to be inserted into
+// an OLM manifests directory.
+//
+// This is required to pass OLM validations which require that namespaced resources do
+// not include explicit namespace settings. OLM automatically installs namespaced
+// resources in the same namespace that the operator is installed in, which is determined
+// at runtime, not bundle/packagemanifests creation time.
+func removeNamespace(obj *unstructured.Unstructured) {
+	obj.SetNamespace("")
+}
+
 func parseStream(in io.Reader) ([]*unstructured.Unstructured, error) {
 	dec := yaml.NewYAMLOrJSONDecoder(in, 1024)
 	var result []*unstructured.Unstructured
@@ -64,6 +75,7 @@ func parseStream(in io.Reader) ([]*unstructured.Unstructured, error) {
 		if u.GetAPIVersion() == "" || u.GetKind() == "" {
 			continue
 		}
+		removeNamespace(u)
 		result = append(result, u)
 	}
 	return result, nil


### PR DESCRIPTION
This is required to pass OLM validations which require that namespaced resources do
not include explicit namespace settings. OLM automatically installs namespaced
resources in the same namespace that the operator is installed in, which is determined
at runtime, not bundle/packagemanifests creation time.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
